### PR TITLE
Fix function signature to match WP_Widget

### DIFF
--- a/chartbeat.php
+++ b/chartbeat.php
@@ -336,7 +336,7 @@ class Chartbeat_Widget extends WP_Widget {
         }
     }
 
-	function widget( $args ) {
+	function widget( $args, $instance ) {
 		extract( $args );
 		echo $before_widget;
 		


### PR DESCRIPTION
Fixes strict warnings about the function signature.

Fixes #10
