### PR TITLE
Remove JS escaping from `amp_post_template_analytics` filter callback

### DIFF
--- a/chartbeat.php
+++ b/chartbeat.php
@@ -402,16 +402,16 @@ function chartbeat_amp_add_analytics( $analytics ) {
 	    'attributes' => array(),
 	    'config_data' => array(
 	        'vars' => array(
-	            'uid' => esc_js($cb_configs["uid"]),
-	            'domain' => esc_js($cb_configs["domain"]),
+	            'uid' => $cb_configs["uid"],
+	            'domain' => $cb_configs["domain"],
 	        )
 	    ),
 	  );
 
 	  $enable_newsbeat = get_option('chartbeat_enable_newsbeat');
 		if ($enable_newsbeat) { 
-			$analytics['chartbeat']['config_data']['vars']['authors'] = esc_js($cb_configs['author']);
-			$analytics['chartbeat']['config_data']['vars']['sections'] = esc_js($cb_configs['sections']);
+			$analytics['chartbeat']['config_data']['vars']['authors'] = $cb_configs['author'];
+			$analytics['chartbeat']['config_data']['vars']['sections'] = $cb_configs['sections'];
 		}
 	}
 	return $analytics;


### PR DESCRIPTION
Removes some extraneous calls to `esc_js` in the `amp_post_template_analytics` filter callback as the nested `config_data` array is already JSON encoded, when printed out to the page, in the AMP plugin:

- https://plugins.trac.wordpress.org/browser/amp/trunk/includes/amp-helper-functions.php#L444
- https://github.com/Automattic/amp-wp/blob/7627ff9ababeb337a6e4b6fcfeb7f21442479246/includes/amp-helper-functions.php#L601

Also the `esc_js` calls don't seem to be as useful since the output goes to the contents of a `application/json` `script` element (i.e., not inline JavaScript):

> Escapes text strings for echoing in JS. It is intended to be used for inline JS (in a tag attribute, for example onclick="…")

https://developer.wordpress.org/reference/functions/esc_js/

Thanks!